### PR TITLE
Add rate iterations limit

### DIFF
--- a/rate.go
+++ b/rate.go
@@ -7,26 +7,36 @@ import (
 )
 
 func Rate(nper, pmt, pv, fv, loanType float64) float64 {
+	rate, _ := RateWithLimit(nper, pmt, pv, fv, loanType, 0)
+	return rate
+}
+
+func RateWithLimit(nper, pmt, pv, fv, loanType, maxIterations float64) (float64, error) {
 	guess := 0.1
 
 	tolerancy := 1e-6
-	close := false
+	isClose := false
 	nextGuess := 0.00
 
-	for !close {
+	var iterations float64
+
+	for !isClose {
+		if maxIterations > 0 && iterations > maxIterations {
+			return 0, fmt.Errorf("iterations limit reached")
+		}
 		temp := newtonIter(guess, nper, pmt, pv, fv, loanType)
-		nextGuess, _ = strconv.ParseFloat(fmt.Sprintf("%.20f", (guess-temp)), 64)
+		nextGuess, _ = strconv.ParseFloat(fmt.Sprintf("%.20f", guess-temp), 64)
 		diff := math.Abs(nextGuess - guess)
-		close = diff < tolerancy
+		isClose = diff < tolerancy
 		guess = nextGuess
+		iterations += 1
 	}
 
-	return (nextGuess * 12 * 100)
-
+	return nextGuess * 12 * 100, nil
 }
 
 func newtonIter(r, n, p, x, y, w float64) float64 {
-	t1 := math.Pow((r + 1), n)
-	t2 := math.Pow((r + 1), (n - 1))
-	return ((y + t1*x + p*(t1-1)*(r*w+1)/r) / (n*t2*x - p*(t1-1)*(r*w+1)/(math.Pow(r, 2)) + n*p*t2*(r*w+1)/r + p*(t1-1)*w/r))
+	t1 := math.Pow(r + 1, n)
+	t2 := math.Pow(r + 1, n - 1)
+	return (y + t1*x + p*(t1-1)*(r*w+1)/r) / (n*t2*x - p*(t1-1)*(r*w+1)/(math.Pow(r, 2)) + n*p*t2*(r*w+1)/r + p*(t1-1)*w/r)
 }

--- a/rate_test.go
+++ b/rate_test.go
@@ -11,3 +11,10 @@ func TestRate(t *testing.T) {
 		t.Errorf("Sum was incorrect, got: %v, want: %v.", rate, rateExpected)
 	}
 }
+
+func TestRateWithLimit(t *testing.T) {
+	_, err := RateWithLimit(14, 3.54017, 44.4057, 0, 0, 100)
+	if err == nil {
+		t.Errorf("limit was not triggered")
+	}
+}


### PR DESCRIPTION
In some cases it's impossible to reach the rate result. In this case, similar libraries in other languages have an iterations limit after which an error is triggered. Here, the iteration limit is not set and, in an unsolvable situation, it just keeps reiterating using all the available CPU.

This PR adds a new function `RateWithLimit`, to avoid breaking existing API.

This also removes some redundant parenthesis in the code, and renames `close` to `isClose` to avoid shadowing the builtin `close` function.